### PR TITLE
Add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.direnv
+.envrc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "A lightweight TUI music player for local files";
+
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      perSystem =
+        { pkgs, ... }:
+        {
+          devShells.default = pkgs.mkShell {
+            strictDeps = true;
+            nativeBuildInputs = [
+              pkgs.cargo
+              pkgs.rustc
+              pkgs.pkg-config
+              pkgs.cmake
+            ];
+
+            buildInputs = [
+              pkgs.ffmpeg
+            ];
+          };
+
+          packages = rec {
+            noctavox = pkgs.callPackage ./nix/package.nix { };
+            default = noctavox;
+          };
+        };
+      flake = {
+      };
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,31 @@
+{
+  lib,
+  rustPlatform,
+  cmake,
+  ffmpeg,
+}:
+let
+  cargoToml = (lib.importTOML ../Cargo.toml);
+in
+rustPlatform.buildRustPackage {
+  pname = cargoToml.package.name;
+  version = cargoToml.package.version;
+
+  src = ./..;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  nativeBuildInputs = [
+    cmake
+  ];
+
+  buildInputs = [
+    ffmpeg
+  ];
+
+  meta = with lib; {
+    description = "A lightweight TUI music player for local files";
+    homepage = "https://github.com/Jaxx497/NoctaVox";
+    license = licenses.mit;
+    mainProgram = "vox";
+  };
+}


### PR DESCRIPTION
Adds a nix flake so that it's easier for people on NixOS to:
- add the software to their configuration 
- contribute to the software (devshell with the necessary dependencies)

and yes, I'm the "people on NixOS" 🤠 

The packaging is pretty simple and actually it could be upstreamed almost as-is to nixpkgs if the package gets more traction.

In the future, it would be nice to also add a `home-manager` module to be able to write the configuration declaratively in nixos.

The only inconvenience is repeating the version number in `package.nix`, but even if it falls out of date with the one in `Cargo.toml` I think it's fine...