### PR TITLE
Clamp min width in layout minimal

### DIFF
--- a/src/tui/layout_minimal.rs
+++ b/src/tui/layout_minimal.rs
@@ -7,6 +7,9 @@ pub struct LayoutMinimal {
     pub widget: Rect,
 }
 
+const MIN_WINDOW_WIDTH: u16 = 50;
+const WIDGET_PERCENTAGE: f32 = 0.12;
+
 impl LayoutMinimal {
     pub fn new(area: Rect, state: &mut UiState) -> Self {
         let is_progress_display = state.is_progress_display();
@@ -23,13 +26,13 @@ impl LayoutMinimal {
             false => 0,
             true => match (state.get_progress_display(), area.height > 20) {
                 (ProgressDisplay::ProgressBar, _) | (_, false) => 3,
-                _ => (area.height as f32 * 0.12).ceil() as u16,
+                _ => (area.height as f32 * WIDGET_PERCENTAGE).ceil() as u16,
             },
         };
 
         let main_area = {
-            let min_width = 60;
-            let width = (area.width / 2).max(min_width).min(area.width - 2);
+            let max_width = area.width.saturating_sub(2).max(MIN_WINDOW_WIDTH);
+            let width = (area.width / 2).clamp(MIN_WINDOW_WIDTH, max_width);
             area.centered_horizontally(Constraint::Length(width))
         };
 

--- a/src/tui/layout_minimal.rs
+++ b/src/tui/layout_minimal.rs
@@ -11,12 +11,12 @@ impl LayoutMinimal {
     pub fn new(area: Rect, state: &mut UiState) -> Self {
         let is_progress_display = state.is_progress_display();
 
-        let search_height = match state.get_mode() == Mode::Search {
-            true => match state.borders_enabled() {
+        let search_height = match state.get_mode() {
+            Mode::Search => match state.borders_enabled() {
                 true => 5,
                 false => 3,
             },
-            false => 0,
+            _ => 0,
         };
 
         let widget_h = match is_progress_display {
@@ -27,21 +27,18 @@ impl LayoutMinimal {
             },
         };
 
-        let [_lpadding, main_area, _rpadding] = Layout::horizontal([
-            Constraint::Percentage(25),
-            Constraint::Fill(1),
-            Constraint::Percentage(25),
-        ])
-        .areas(area);
-
-        let legal_songs_len = state.get_legal_songs().len();
+        let main_area = {
+            let min_width = 60;
+            let width = (area.width / 2).max(min_width).min(area.width - 2);
+            area.centered_horizontally(Constraint::Length(width))
+        };
 
         let item_count = match state.get_pane() {
             Pane::SideBar => match state.get_sidebar_view() {
                 LibraryView::Albums => state.albums.len(),
                 LibraryView::Playlists => state.playlists.len(),
             },
-            _ => legal_songs_len,
+            _ => state.get_legal_songs().len(),
         };
 
         let max_h = (area.height as f64 * 0.5).ceil() as u16;
@@ -60,15 +57,10 @@ impl LayoutMinimal {
         .areas(main_area);
 
         let [search_bar, song_window] =
-            Layout::vertical([Constraint::Length(search_height), Constraint::Fill(100)])
+            Layout::vertical([Constraint::Length(search_height), Constraint::Fill(1)])
                 .areas(upper_block);
 
-        let [_, widget, _] = Layout::horizontal([
-            Constraint::Percentage(10),
-            Constraint::Fill(1),
-            Constraint::Percentage(10),
-        ])
-        .areas(widget_spacing);
+        let widget = widget_spacing.centered_horizontally(Constraint::Percentage(80));
 
         LayoutMinimal {
             search_bar,


### PR DESCRIPTION
The minimal view uses 50% of the width, which works fine if the window is large, but I wanted to have a column and the space really seem wasted. Here's a before and after of what I mean:

Old:
https://github.com/user-attachments/assets/9d7ec941-c361-4252-ab07-660c02914f2d

New:
https://github.com/user-attachments/assets/5ffa72d7-3444-48a6-b660-7085e515ae7b

(notice what happens when the window is skinny)

The logic is a bit more imperative than I'd like, but it's not too complicated. Also I noticed I changed a couple small things kind of in autopilot, I hope it's fine :sweat_smile: